### PR TITLE
improved handling of colors with grouping vs facetting

### DIFF
--- a/R/geom_coverage.R
+++ b/R/geom_coverage.R
@@ -3,7 +3,7 @@
 #' @param data Track prepared by \code{\link{FormatTrack}}.
 #' @param mapping Set of aesthetic mappings created by \code{aes} or \code{aes_}. Default: NULL.
 #' @param color Track color. Default: NULL (select automatically).
-#' @param rect.color The color of every bin. Default: NA.
+#' @param rect.color The color of every bin. Default: NA
 #' @param single.nuc Logical value, whether to visualize at single nucleotide level (use bar plot). Default: FALSE.
 #' @param plot.type The type of the plot, choose from facet (separate plot for every sample) and
 #' joint (combine all sample in a single plot). Default: facet.
@@ -37,20 +37,63 @@
 #'
 #' @export
 #' @examples
-#' # library(ggcoverage)
-#' # library(utils)
-#' # library(ggplot2)
-#' # meta.file <- system.file("extdata", "RNA-seq", "meta_info.csv", package = "ggcoverage")
-#' # sample.meta <- utils::read.csv(meta.file)
-#' # track folder
-#' # track.folder <- system.file("extdata", "RNA-seq", package = "ggcoverage")
-#' # load bigwig file
-#' # track.df <- LoadTrackFile(
-#' #   track.folder = track.folder, format = "bw",
-#' #   meta.info = sample.meta
-#' # )
-#' # ggplot() +
-#' #   geom_coverage(data = track.df, color = NULL, mark.region = NULL)
+#' library(ggcoverage)
+#' library(ggplot2)
+#'
+#' # import track data
+#' meta.file <- system.file("extdata", "RNA-seq", "meta_info.csv", package = "ggcoverage")
+#' sample.meta <- utils::read.csv(meta.file)
+#' track.folder <- system.file("extdata", "RNA-seq", package = "ggcoverage")
+#'
+#' track.df <- LoadTrackFile(
+#'   track.folder = track.folder, format = "bw",
+#'   meta.info = sample.meta
+#' )
+#'
+#' # plot tracks with coloring by 'Group' variable
+#' ggplot() +
+#'   geom_coverage(data = track.df, facet.key = "Type", group.key = "Group")
+#'
+#' # plot tracks without coloring by any group
+#' ggplot() +
+#'   geom_coverage(data = track.df, facet.key = "Type", group.key = NULL)
+#'
+#' # plot tracks with coloring each facet differently (facet.key == group.key)
+#' ggplot() +
+#'   geom_coverage(data = track.df, facet.key = "Type", group.key = "Type")
+#'
+#' # supply your own colors
+#' ggplot() +
+#'   geom_coverage(
+#'     data = track.df, facet.key = "Type",
+#'     group.key = "Type", color = 1:4,
+#'     facet.color = 1:4
+#'   )
+#'
+#' # plot tracks together in one panel instead of separately;
+#' # 'facet.key' is not needed
+#' ggplot() +
+#'   geom_coverage(
+#'     data = track.df, group.key = "Type",
+#'     plot.type = "joint"
+#'   )
+#'
+#' # use a custom theme
+#' ggplot() +
+#'   geom_coverage(data = track.df, facet.key = "Type") +
+#'   theme_bw()
+#'
+#' # mark a region
+#' ggplot() +
+#'   geom_coverage(
+#'     data = track.df, facet.key = "Type",
+#'     mark.region = data.frame(
+#'       start = c(21678900,21732001,21737590),
+#'       end = c(21679900,21732400,21737650),
+#'       label=c("M1", "M2", "M3")),
+#'     mark.color = grey(0.4)
+#'   )
+#'
 geom_coverage <- function(data, mapping = NULL, color = NULL, rect.color = NA,
                           single.nuc = FALSE, plot.type = c("facet", "joint"),
                           facet.key = "Type", joint.avg = FALSE, facet.order = NULL,
@@ -185,11 +228,13 @@ geom_coverage <- function(data, mapping = NULL, color = NULL, rect.color = NA,
     facet.formula <- as.formula(paste0("~ ", facet.key))
     if (!single.nuc) {
       region.rect <- geom_rect(data = data, mapping = mapping, show.legend = F, colour = rect.color)
+      ymax.str <- rlang::as_label(mapping$ymax)
     } else {
       region.rect <- geom_bar(
         data = data, mapping = mapping, show.legend = F, colour = rect.color,
         stat = "identity"
       )
+      ymax.str <- rlang::as_label(mapping$y)
     }
     # prepare facet scale
     if (facet.y.scale == "free") {
@@ -210,8 +255,6 @@ geom_coverage <- function(data, mapping = NULL, color = NULL, rect.color = NA,
       plot.ele <- append(plot.ele, sacle_fill_cols)
     }
 
-    # add range text to track
-    ymax.str <- rlang::as_label(mapping$ymax)
     if (range.position == "in") {
       data.range <- data %>%
         dplyr::group_by(.data[[facet.key]]) %>%

--- a/R/geom_coverage.R
+++ b/R/geom_coverage.R
@@ -258,9 +258,11 @@ geom_coverage <- function(data, mapping = NULL, color = NULL, rect.color = NA,
     if (range.position == "in") {
       data.range <- data %>%
         dplyr::group_by(.data[[facet.key]]) %>%
-        dplyr::summarise(max_score = max(.data[[ymax.str]]))
-      data.range$max_score <- sapply(data.range$max_score, CeilingNumber)
-      data.range$label <- paste0("[0, ", data.range$max_score, "]")
+        dplyr::summarise(.groups = "drop_last",
+                         min_score = CeilingNumber(min(.data[[ymax.str]])),
+                         max_score = CeilingNumber(max(.data[[ymax.str]]))
+        )
+      data.range$label <- paste0("[", data.range$min_score, ", ", data.range$max_score, "]")
       region.range <- geom_text(
         data = data.range,
         mapping = aes(x = -Inf, y = Inf, label = label),
@@ -349,7 +351,7 @@ geom_coverage <- function(data, mapping = NULL, color = NULL, rect.color = NA,
 
     region.mark <- geom_rect(
       data = valid.region.df,
-      aes_string(xmin = "start", xmax = "end", ymin = "0", ymax = "Inf"),
+      aes_string(xmin = "start", xmax = "end", ymin = "-Inf", ymax = "Inf"),
       fill = mark.color, alpha = mark.alpha
     )
     plot.ele <- append(plot.ele, region.mark)

--- a/R/ggcoverage.R
+++ b/R/ggcoverage.R
@@ -40,19 +40,64 @@
 #' @export
 #'
 #' @examples
-#' # library(ggcoverage)
-#' # library(utils)
-#' # library(rtracklayer)
-#' # meta.file <- system.file("extdata", "RNA-seq", "meta_info.csv", package = "ggcoverage")
-#' # sample.meta <- utils::read.csv(meta.file)
-#' # track folder
-#' # track.folder <- system.file("extdata", "RNA-seq", package = "ggcoverage")
-#' # load bigwig file
-#' # track.df <- LoadTrackFile(track.folder = track.folder, format = "bw",region = "chr14:21,677,306-21,737,601",
-#' #                           extend = 2000, meta.info = sample.meta)
-#' # gtf.file <- system.file("extdata", "used_hg19.gtf", package = "ggcoverage")
-#' # gtf.gr <- rtracklayer::import.gff(con = gtf.file, format = "gtf")
-#' # ggcoverage(data = track.df, color = "auto", range.position = "out")
+#' library(ggcoverage)
+#' library(rtracklayer)
+#' library(ggplot2)
+#'
+#' # import track data
+#' meta.file <- system.file("extdata", "RNA-seq", "meta_info.csv", package = "ggcoverage")
+#' sample.meta <- read.csv(meta.file)
+#' track.folder <- system.file("extdata", "RNA-seq", package = "ggcoverage")
+#'
+#' track.df <- LoadTrackFile(
+#'   track.folder = track.folder, format = "bw",
+#'   region = "chr14:21,677,306-21,737,601",
+#'   extend = 2000, meta.info = sample.meta
+#' )
+#'
+#' gtf.file <- system.file("extdata", "used_hg19.gtf", package = "ggcoverage")
+#' gtf.gr <- rtracklayer::import.gff(con = gtf.file, format = "gtf")
+#'
+#' # plot tracks with coloring by 'Group' variable
+#' ggcoverage(data = track.df, facet.key = "Type", group.key = "Group")
+#'
+#' # plot tracks without coloring by any group
+#' ggcoverage(data = track.df, facet.key = "Type", group.key = NULL)
+#'
+#' # plot tracks with coloring each facet differently (facet.key == group.key)
+#' ggcoverage(data = track.df, facet.key = "Type", group.key = "Type")
+#'
+#' # supply your own colors
+#' ggcoverage(
+#'   data = track.df, facet.key = "Type",
+#'   group.key = "Type", color = 1:4,
+#'   facet.color = 1:4
+#' )
+#'
+#' # plot tracks together in one panel instead of separately;
+#' # 'facet.key' is not needed
+#' ggcoverage(
+#'   data = track.df, group.key = "Type",
+#'   plot.type = "joint"
+#' )
+#'
+#' # use a custom theme
+#' ggcoverage(data = track.df, facet.key = "Type") +
+#'   theme_bw()
+#'
+#' # mark a region
+#' ggcoverage(
+#'   data = track.df, facet.key = "Type",
+#'   mark.region = data.frame(
+#'     start = c(21678900,21732001,21737590),
+#'     end = c(21679900,21732400,21737650),
+#'     label=c("M1", "M2", "M3")),
+#'   mark.color = grey(0.4)
+#' )
+#'
+#' # position range labels outside of tracks
+#' ggcoverage(data = track.df, facet.key = "Type", range.position = "out")
+#'
 ggcoverage <- function(data, single.nuc = FALSE, mapping = NULL, color = NULL,
                        rect.color = NA, plot.type = c("facet", "joint"), facet.key = "Type", joint.avg = FALSE,
                        facet.order = NULL, facet.color = NULL, facet.y.scale = c("free", "fixed"),

--- a/R/utils.R
+++ b/R/utils.R
@@ -66,7 +66,6 @@ AutoColor <- function(data, n, name, key) {
 
 # ceiling for number bigger than zero, floor for number smaller than zero
 CeilingNumber <- function(x, digits = 2) {
-  print(x)
   if (x == 0) {
     "0"
   } else if (abs(x) >= 10^6) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -66,28 +66,17 @@ AutoColor <- function(data, n, name, key) {
 
 # ceiling for number bigger than zero, floor for number smaller than zero
 CeilingNumber <- function(x, digits = 2) {
-  # mark number
-  if (x < 0) {
-    flag <- -1
-    x <- abs(x)
+  if (x == 0) {
+    "0"
+  } else if (abs(x) >= 10^6) {
+    formatC(x, format = "e", digits = 2)
+  } else if (abs(x) >= 10000) {
+    formatC(round(x), format = "f", digits = 0)
+  } else if ((x %% floor(x)) != 0) {
+    formatC(x, format = "f", digits = 2)
   } else {
-    flag <- 1
+    formatC(x, format = "f", digits = 0)
   }
-  # transfrom
-  if (x > 1) {
-    x.ceiling <- round(x + 5 * 10^(-digits - 1), digits)
-  } else if (x > 0) {
-    x.split <- unlist(strsplit(formatC(x, format = "e"), "e"))
-    num.part <- as.numeric(x.split[1])
-    sci.part <- as.numeric(x.split[2])
-    valid.digits <- digits - 1
-    x.ceiling <- round(num.part + 5 * 10^(-valid.digits - 1), valid.digits) * 10^(sci.part)
-  } else {
-    x.ceiling <- 0
-  }
-  # final number
-  x.final <- x.ceiling * flag
-  return(x.final)
 }
 
 # create aa plot dataframe with padding offset

--- a/R/utils.R
+++ b/R/utils.R
@@ -66,16 +66,21 @@ AutoColor <- function(data, n, name, key) {
 
 # ceiling for number bigger than zero, floor for number smaller than zero
 CeilingNumber <- function(x, digits = 2) {
+  print(x)
   if (x == 0) {
     "0"
   } else if (abs(x) >= 10^6) {
     formatC(x, format = "e", digits = 2)
   } else if (abs(x) >= 10000) {
     formatC(round(x), format = "f", digits = 0)
-  } else if ((x %% floor(x)) != 0) {
-    formatC(x, format = "f", digits = 2)
+  } else if (abs(x) >= 1) {
+    if ((x %% floor(x)) != 0) {
+      formatC(x, format = "f", digits = 2)
+    } else {
+      formatC(x, format = "f", digits = 0)
+    }
   } else {
-    formatC(x, format = "f", digits = 0)
+    formatC(x, format = "f", digits = 2)
   }
 }
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -122,7 +122,7 @@ The basic coverage plot has **two types**:
 #### joint view
 Create line plot for **every sample** (`facet.key = "Type"`) and color by **every sample** (`group.key = "Type"`):
 ```{r basic_coverage_joint, warning=FALSE, fig.height = 4, fig.width = 12, fig.align = "center"}
-basic.coverage = ggcoverage(data = track.df, color = "auto", 
+basic.coverage = ggcoverage(data = track.df,
                             plot.type = "joint", facet.key = "Type", group.key = "Type",
                             mark.region = mark.region, range.position = "out")
 basic.coverage
@@ -130,7 +130,7 @@ basic.coverage
 
 Create **group average line plot** (sample is indicated by `facet.key = "Type"`, group is indicated by `group.key = "Group"`):
 ```{r basic_coverage_joint_avg, warning=FALSE, fig.height = 4, fig.width = 12, fig.align = "center"}
-basic.coverage = ggcoverage(data = track.df, color = "auto", 
+basic.coverage = ggcoverage(data = track.df,
                             plot.type = "joint", facet.key = "Type", group.key = "Group", 
                             joint.avg = TRUE,
                             mark.region = mark.region, range.position = "out")
@@ -139,7 +139,7 @@ basic.coverage
 
 #### facet view
 ```{r basic_coverage, warning=FALSE, fig.height = 6, fig.width = 12, fig.align = "center"}
-basic.coverage = ggcoverage(data = track.df, color = "auto", plot.type = "facet",
+basic.coverage = ggcoverage(data = track.df, plot.type = "facet",
                             mark.region = mark.region, range.position = "out")
 basic.coverage
 ```
@@ -147,14 +147,14 @@ basic.coverage
 #### Custom Y-axis style
 **Change the Y-axis scale label in/out of plot region with `range.position`**:
 ```{r basic_coverage_2, warning=FALSE, fig.height = 6, fig.width = 12, fig.align = "center"}
-basic.coverage = ggcoverage(data = track.df, color = "auto", plot.type = "facet",
+basic.coverage = ggcoverage(data = track.df, plot.type = "facet",
                             mark.region = mark.region, range.position = "in")
 basic.coverage
 ```
 
 **Shared/Free Y-axis scale with `facet.y.scale`**:
 ```{r basic_coverage_3, warning=FALSE, fig.height = 6, fig.width = 12, fig.align = "center"}
-basic.coverage = ggcoverage(data = track.df, color = "auto", plot.type = "facet",
+basic.coverage = ggcoverage(data = track.df, plot.type = "facet",
                             mark.region = mark.region, range.position = "in", 
                             facet.y.scale = "fixed")
 basic.coverage
@@ -422,7 +422,7 @@ mark.region
 
 ### Basic coverage
 ```{r basic_coverage_chip, warning=FALSE, fig.height = 6, fig.width = 12, fig.align = "center"}
-basic.coverage = ggcoverage(data = track.df, color = "auto", 
+basic.coverage = ggcoverage(data = track.df,
                             mark.region=mark.region, show.mark.label = FALSE)
 basic.coverage
 ```

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Create line plot for **every sample** (`facet.key = "Type"`) and color
 by **every sample** (`group.key = "Type"`):
 
 ``` r
-basic.coverage = ggcoverage(data = track.df, color = "auto", 
+basic.coverage = ggcoverage(data = track.df,
                             plot.type = "joint", facet.key = "Type", group.key = "Type",
                             mark.region = mark.region, range.position = "out")
 basic.coverage
@@ -176,7 +176,7 @@ Create **group average line plot** (sample is indicated by
 `facet.key = "Type"`, group is indicated by `group.key = "Group"`):
 
 ``` r
-basic.coverage = ggcoverage(data = track.df, color = "auto", 
+basic.coverage = ggcoverage(data = track.df,
                             plot.type = "joint", facet.key = "Type", group.key = "Group", 
                             joint.avg = TRUE,
                             mark.region = mark.region, range.position = "out")
@@ -188,7 +188,7 @@ basic.coverage
 #### facet view
 
 ``` r
-basic.coverage = ggcoverage(data = track.df, color = "auto", plot.type = "facet",
+basic.coverage = ggcoverage(data = track.df, plot.type = "facet",
                             mark.region = mark.region, range.position = "out")
 basic.coverage
 ```
@@ -201,7 +201,7 @@ basic.coverage
 `range.position`**:
 
 ``` r
-basic.coverage = ggcoverage(data = track.df, color = "auto", plot.type = "facet",
+basic.coverage = ggcoverage(data = track.df, plot.type = "facet",
                             mark.region = mark.region, range.position = "in")
 basic.coverage
 ```
@@ -211,7 +211,7 @@ basic.coverage
 **Shared/Free Y-axis scale with `facet.y.scale`**:
 
 ``` r
-basic.coverage = ggcoverage(data = track.df, color = "auto", plot.type = "facet",
+basic.coverage = ggcoverage(data = track.df, plot.type = "facet",
                             mark.region = mark.region, range.position = "in", 
                             facet.y.scale = "fixed")
 basic.coverage
@@ -635,7 +635,7 @@ mark.region
 ### Basic coverage
 
 ``` r
-basic.coverage = ggcoverage(data = track.df, color = "auto", 
+basic.coverage = ggcoverage(data = track.df,
                             mark.region=mark.region, show.mark.label = FALSE)
 basic.coverage
 ```

--- a/vignettes/CustomizeThePlot.Rmd
+++ b/vignettes/CustomizeThePlot.Rmd
@@ -76,7 +76,7 @@ mark.region=data.frame(start=c(76822533),
 # check data
 mark.region
 # create basic coverage plot
-basic.coverage = ggcoverage(data = track.df, color = "auto", range.position = "out",
+basic.coverage = ggcoverage(data = track.df, range.position = "out",
                             mark.region=mark.region, show.mark.label = FALSE)
 basic.coverage
 ```

--- a/vignettes/ggcoverage.Rmd
+++ b/vignettes/ggcoverage.Rmd
@@ -138,7 +138,7 @@ The basic coverage plot has **two types**:
 #### joint view
 Create line plot for **every sample** (`facet.key = "Type"`) and color by **every sample** (`group.key = "Type"`):
 ```{r basic_coverage_joint, eval=FALSE}
-basic.coverage = ggcoverage(data = track.df, color = "auto", 
+basic.coverage = ggcoverage(data = track.df,
                             plot.type = "joint", facet.key = "Type", group.key = "Type",
                             mark.region = mark.region, range.position = "out")
 basic.coverage
@@ -150,7 +150,7 @@ knitr::include_graphics("../man/figures/README-basic_coverage_joint-1.png")
 
 Create **group average line plot** (sample is indicated by `facet.key = "Type"`, group is indicated by `group.key = "Group"`):
 ```{r basic_coverage_joint_avg, eval=FALSE}
-basic.coverage = ggcoverage(data = track.df, color = "auto", 
+basic.coverage = ggcoverage(data = track.df,
                             plot.type = "joint", facet.key = "Type", group.key = "Group", 
                             joint.avg = TRUE,
                             mark.region = mark.region, range.position = "out")
@@ -163,7 +163,7 @@ knitr::include_graphics("../man/figures/README-basic_coverage_joint_avg-1.png")
 
 #### facet view
 ```{r basic_coverage, eval=FALSE}
-basic.coverage = ggcoverage(data = track.df, color = "auto", plot.type = "facet",
+basic.coverage = ggcoverage(data = track.df, plot.type = "facet",
                             mark.region = mark.region, range.position = "out")
 basic.coverage
 ```
@@ -175,7 +175,7 @@ knitr::include_graphics("../man/figures/README-basic_coverage-1.png")
 #### Custom Y-axis style
 **Change the Y-axis scale label in/out of plot region with `range.position`**:
 ```{r basic_coverage_2, eval=FALSE}
-basic.coverage = ggcoverage(data = track.df, color = "auto", plot.type = "facet",
+basic.coverage = ggcoverage(data = track.df, plot.type = "facet",
                             mark.region = mark.region, range.position = "in")
 basic.coverage
 ```
@@ -186,7 +186,7 @@ knitr::include_graphics("../man/figures/README-basic_coverage_2-1.png")
 
 **Shared/Free Y-axis scale with `facet.y.scale`**:
 ```{r basic_coverage_3, eval=FALSE}
-basic.coverage = ggcoverage(data = track.df, color = "auto", plot.type = "facet",
+basic.coverage = ggcoverage(data = track.df, plot.type = "facet",
                             mark.region = mark.region, range.position = "in", 
                             facet.y.scale = "fixed")
 basic.coverage
@@ -519,7 +519,7 @@ mark.region
 
 ## Basic coverage
 ```{r basic_coverage_chip, eval=FALSE}
-basic.coverage = ggcoverage(data = track.df, color = "auto", 
+basic.coverage = ggcoverage(data = track.df,
                             mark.region=mark.region, show.mark.label = FALSE)
 basic.coverage
 ```


### PR DESCRIPTION
- groups and facets can be colored indepently
- default is now to color tracks by "group.key" variable
- added more detailed examples for `ggcoverage` and `geom_coverage`
- removed `color = "auto"` from vignettes, which had and still has no effect